### PR TITLE
Add support for passing options as functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,15 +73,6 @@ export default function rehypeExternalLinks(options = {}) {
         const url = node.properties.href
         const protocol = url.slice(0, url.indexOf(':'))
 
-        const options_ =
-          typeof options === 'function' ? options(node, tree) : options
-        const exclude = options_.exclude || []
-
-        // Rehype camelizes some properties and doesn't for some others, to gurantee compatibility
-        // and avoid edge cases, I'm camelizing everything manually,
-        const propertyKeys = new Set(
-          Object.keys(node.properties).map((x) => camelCase(x))
-        )
         const noExcludeProperties = exclude.every(
           (x) => !propertyKeys.has(camelCase(x))
         )

--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@
  *
  * @typedef Options
  *   Configuration.
- * @property {string[]} [exclude=[]]
- *   Exclude anchors with the following attributes from `rehype-external-links`
  * @property {'_self'|'_blank'|'_parent'|'_top'|false} [target='_blank']
  *   How to display referenced documents (`string?`: `_self`, `_blank`,
  *   `_parent`, or `_top`, default: `_blank`).

--- a/index.js
+++ b/index.js
@@ -65,11 +65,15 @@ const defaultRel = ['nofollow', 'noopener', 'noreferrer']
 const defaultProtocols = ['http', 'https']
 
 /**
+ * If this is a value, return that.
+ * If this is a function instead, call it to get the result.
  *
- * @param {Options[keyof Options]} value
+ * @template T
+ * @param {T} value
  * @param {Element} node
+ * @returns {T extends Function ? ReturnType<T> : T}
  */
-function createFunction(value, node) {
+function callIfNeeded(value, node) {
   return typeof value === 'function' ? value(node) : value
 }
 
@@ -89,27 +93,20 @@ export default function rehypeExternalLinks(options = {}) {
         const url = node.properties.href
         const protocol = url.slice(0, url.indexOf(':'))
 
-        const target = /** @type {Target} */ (
-          createFunction(options.target, node)
-        )
+        const target = callIfNeeded(options.target, node)
 
-        const _rel = /** @type {Rel} */ (createFunction(options.rel, node))
+        const _rel = callIfNeeded(options.rel, node)
         const rel = typeof _rel === 'string' ? parse(_rel) : _rel
 
         const protocols =
-          /** @type {Protocols} */ (createFunction(options.protocols, node)) ||
-          defaultProtocols
+          callIfNeeded(options.protocols, node) || defaultProtocols
 
-        const _content = /** @type {Content} */ (
-          createFunction(options.content, node)
-        )
+        const _content = callIfNeeded(options.content, node)
         const content =
           _content && !Array.isArray(_content) ? [_content] : _content
 
         const contentProperties =
-          /** @type {ContentProperties} */ (
-            createFunction(options.contentProperties, node)
-          ) || {}
+          callIfNeeded(options.contentProperties, node) || {}
 
         if (absolute(url) && protocols.includes(protocol)) {
           if (target !== false) {

--- a/readme.md
+++ b/readme.md
@@ -12,17 +12,25 @@
 
 ## Contents
 
-*   [What is this?](#what-is-this)
-*   [When should I use this?](#when-should-i-use-this)
-*   [Install](#install)
-*   [Use](#use)
-*   [API](#api)
-    *   [`unified().use(rehypeExternalLinks[, options])`](#unifieduserehypeexternallinks-options)
-*   [Types](#types)
-*   [Compatibility](#compatibility)
-*   [Security](#security)
-*   [Contribute](#contribute)
-*   [License](#license)
+- [rehype-external-links](#rehype-external-links)
+  - [Contents](#contents)
+  - [What is this?](#what-is-this)
+  - [When should I use this?](#when-should-i-use-this)
+  - [Install](#install)
+  - [Use](#use)
+  - [API](#api)
+    - [`unified().use(rehypeExternalLinks[, options])`](#unifieduserehypeexternallinks-options)
+        - [`options`](#options)
+          - [`options.target`](#optionstarget)
+          - [`options.rel`](#optionsrel)
+          - [`options.protocols`](#optionsprotocols)
+          - [`options.content`](#optionscontent)
+          - [`options.contentProperties`](#optionscontentproperties)
+  - [Types](#types)
+  - [Compatibility](#compatibility)
+  - [Security](#security)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## What is this?
 
@@ -113,31 +121,26 @@ Add `rel` (and `target`) to external links.
 ##### `options`
 
 Configuration (optional).
-It can also be a function which returns an options object.
+Each config option can also be a callback function which has 
+a node as an argument, and returns the corresponding config values.
+
+e.g.
 
 ```ts
-await rehype()
-.use(
-  rehypeExternalLinks,
-
-  // You may need to coerce the types to avoid vscode leaving errors everywhere
-  /** @type {import("rehype-external-links").inputOptions} */
-  ((node, tree) => {
-    return {
-      target: node.properties.id == 5 ? "_blank" : false
-    };
-  })
-)
+{
+  target(node) {
+    return node.properties.id == 5 ? "_blank" : false;
+  }
+}
 ...
 ```
 
 Or
 
 ```ts
-await rehype()
-.use(rehypeExternalLinks, {
+{
   target: "_blank"
-})
+}
 ...
 ```
 
@@ -179,22 +182,6 @@ Will be inserted in a `<span>` element.
 
 Attributes to add to the `<span>`s wrapping `options.content`
 ([`Properties`][properties], optional).
-
-###### `options.exclude`
-
-Excludes all anchors which have a property in the excluded array
-of property names from being processed by `rehype-external-links`.
-
-```ts
-{
-  // Anchor with any of these properties 
-  // will be excluded
-  exclude: ["target", "data-not-external", ...]
-}
-```
-
-> 👉 **Note**: if you use a function for the options
-> configuration object, it won’t unset the `exclude` config option.
 
 ## Types
 

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,33 @@ Add `rel` (and `target`) to external links.
 ##### `options`
 
 Configuration (optional).
+It can also be a function which returns an options object.
+
+```ts
+await rehype()
+.use(
+  rehypeExternalLinks,
+
+  // You may need to coerce the types to avoid vscode leaving errors everywhere
+  /** @type {import("rehype-external-links").inputOptions} */
+  ((node, tree) => {
+    return {
+      target: node.properties.id == 5 ? "_blank" : false
+    };
+  })
+)
+...
+```
+
+Or
+
+```ts
+await rehype()
+.use(rehypeExternalLinks, {
+  target: "_blank"
+})
+...
+```
 
 ###### `options.target`
 
@@ -152,6 +179,22 @@ Will be inserted in a `<span>` element.
 
 Attributes to add to the `<span>`s wrapping `options.content`
 ([`Properties`][properties], optional).
+
+###### `options.exclude`
+
+Excludes all anchors which have a property in the excluded array
+of property names from being processed by `rehype-external-links`.
+
+```ts
+{
+  // Anchor with any of these properties 
+  // will be excluded
+  exclude: ["target", "data-not-external", ...]
+}
+```
+
+> 👉 **Note**: if you use a function for the options
+> configuration object, it won’t unset the `exclude` config option.
 
 ## Types
 

--- a/readme.md
+++ b/readme.md
@@ -12,25 +12,17 @@
 
 ## Contents
 
-- [rehype-external-links](#rehype-external-links)
-  - [Contents](#contents)
-  - [What is this?](#what-is-this)
-  - [When should I use this?](#when-should-i-use-this)
-  - [Install](#install)
-  - [Use](#use)
-  - [API](#api)
-    - [`unified().use(rehypeExternalLinks[, options])`](#unifieduserehypeexternallinks-options)
-        - [`options`](#options)
-          - [`options.target`](#optionstarget)
-          - [`options.rel`](#optionsrel)
-          - [`options.protocols`](#optionsprotocols)
-          - [`options.content`](#optionscontent)
-          - [`options.contentProperties`](#optionscontentproperties)
-  - [Types](#types)
-  - [Compatibility](#compatibility)
-  - [Security](#security)
-  - [Contribute](#contribute)
-  - [License](#license)
+*   [What is this?](#what-is-this)
+*   [When should I use this?](#when-should-i-use-this)
+*   [Install](#install)
+*   [Use](#use)
+*   [API](#api)
+    *   [`unified().use(rehypeExternalLinks[, options])`](#unifieduserehypeexternallinks-options)
+*   [Types](#types)
+*   [Compatibility](#compatibility)
+*   [Security](#security)
+*   [Contribute](#contribute)
+*   [License](#license)
 
 ## What is this?
 
@@ -121,7 +113,7 @@ Add `rel` (and `target`) to external links.
 ##### `options`
 
 Configuration (optional).
-Each config option can also be a callback function which has 
+Each config option can also be a callback function which has
 a node as an argument, and returns the corresponding config values.
 
 e.g.

--- a/test.js
+++ b/test.js
@@ -204,8 +204,8 @@ test('rehypeExternalLinks', async (t) => {
           /** @type {import("./index.js").inputOptions} */ (
             (node) => {
               // True, If node doesn't contain an image
-              const noImage = node?.children?.every((x) => {
-                if (x.type === 'element') return x?.tagName !== 'img'
+              const noImage = node.children.every((x) => {
+                if (x.type === 'element') return x.tagName !== 'img'
                 return true
               })
               return {
@@ -234,9 +234,9 @@ test('rehypeExternalLinks', async (t) => {
           /** @type {import("./index.js").inputOptions} */ (
             (node, tree) => {
               // True, If parent node is a div
-              const divParent = tree?.children.some((x) => {
+              const divParent = tree.children.some((x) => {
                 if (x.type === 'element') {
-                  return x?.tagName === 'div' && x?.children?.includes(node)
+                  return x.tagName === 'div' && x.children.includes(node)
                 }
 
                 return false
@@ -268,8 +268,8 @@ test('rehypeExternalLinks', async (t) => {
           /** @type {import("./index.js").inputOptions} */ (
             (node) => {
               // True, If node doesn't contains an image
-              const noImage = !node?.children?.every((x) => {
-                if (x.type === 'element') return x?.tagName !== 'img'
+              const noImage = !node.children.every((x) => {
+                if (x.type === 'element') return x.tagName !== 'img'
                 return true
               })
 
@@ -299,8 +299,8 @@ test('rehypeExternalLinks', async (t) => {
           /** @type {import("./index.js").inputOptions} */ (
             (node) => {
               // True, If node doesn't contains an image
-              const noImage = node?.children?.every((x) => {
-                if (x.type === 'element') return x?.tagName !== 'img'
+              const noImage = node.children.every((x) => {
+                if (x.type === 'element') return x.tagName !== 'img'
                 return true
               })
               return {

--- a/test.js
+++ b/test.js
@@ -199,24 +199,19 @@ test('rehypeExternalLinks', async (t) => {
     String(
       await rehype()
         .use({settings: {fragment: true}})
-        .use(
-          rehypeExternalLinks,
-          /** @type {import("./index.js").inputOptions} */ (
-            (node) => {
-              // True, If node doesn't contain an image
-              const noImage = node.children.every((x) => {
-                if (x.type === 'element') return x.tagName !== 'img'
-                return true
-              })
-              return {
-                contentProperties: {className: ['alpha', 'bravo']},
-                content: noImage
-                  ? {type: 'text', value: ' (opens in a new window)'}
-                  : null
-              }
-            }
-          )
-        )
+        .use(rehypeExternalLinks, {
+          contentProperties: {className: ['alpha', 'bravo']},
+          content(node) {
+            // True, If node doesn't contain an image
+            const noImage = node.children.every((x) => {
+              if (x.type === 'element') return x.tagName !== 'img'
+              return true
+            })
+
+            if (noImage)
+              return {type: 'text', value: ' (opens in a new window)'}
+          }
+        })
         .process(
           `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
         )
@@ -229,59 +224,18 @@ test('rehypeExternalLinks', async (t) => {
     String(
       await rehype()
         .use({settings: {fragment: true}})
-        .use(
-          rehypeExternalLinks,
-          /** @type {import("./index.js").inputOptions} */ (
-            (node, tree) => {
-              // True, If parent node is a div
-              const divParent = tree.children.some((x) => {
-                if (x.type === 'element') {
-                  return x.tagName === 'div' && x.children.includes(node)
-                }
+        .use(rehypeExternalLinks, {
+          contentProperties(node) {
+            // True, If node doesn't contains an image
+            const noImage = !node.children.every((x) => {
+              if (x.type === 'element') return x.tagName !== 'img'
+              return true
+            })
 
-                return false
-              })
-
-              return {
-                contentProperties: {className: ['alpha', 'bravo']},
-                content: divParent
-                  ? null
-                  : {type: 'text', value: ' (opens in a new window)'}
-              }
-            }
-          )
-        )
-        .process(
-          `<div><a href="http://example.com">http</a></div>\n<a href="http://example.com"><img src="./image.png" /></a>`
-        )
-    ),
-    `<div><a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http</a></div>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
-    "should only add (open in window) text to the span at the end of the link w/ a `options(node, tree)` function, whose tree doesn't has a `div` element as the parent of one of the node"
-  )
-
-  t.equal(
-    String(
-      await rehype()
-        .use({settings: {fragment: true}})
-        .use(
-          rehypeExternalLinks,
-          /** @type {import("./index.js").inputOptions} */ (
-            (node) => {
-              // True, If node doesn't contains an image
-              const noImage = !node.children.every((x) => {
-                if (x.type === 'element') return x.tagName !== 'img'
-                return true
-              })
-
-              return {
-                contentProperties: noImage
-                  ? {className: ['alpha', 'bravo']}
-                  : null,
-                content: {type: 'text', value: ' (opens in a new window)'}
-              }
-            }
-          )
-        )
+            if (noImage) return {className: ['alpha', 'bravo']}
+          },
+          content: {type: 'text', value: ' (opens in a new window)'}
+        })
         .process(
           `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
         )
@@ -294,53 +248,34 @@ test('rehypeExternalLinks', async (t) => {
     String(
       await rehype()
         .use({settings: {fragment: true}})
-        .use(
-          rehypeExternalLinks,
-          /** @type {import("./index.js").inputOptions} */ (
-            (node) => {
-              // True, If node doesn't contains an image
-              const noImage = node.children.every((x) => {
-                if (x.type === 'element') return x.tagName !== 'img'
-                return true
-              })
-              return {
-                target: noImage ? '_blank' : false,
-                rel: noImage ? ['noopener', 'noreferrer'] : 'nofollow',
-                contentProperties: {className: ['alpha', 'bravo']},
-                content: {type: 'text', value: ' (opens in a new window)'}
-              }
-            }
-          )
-        )
+        .use(rehypeExternalLinks, {
+          target(node) {
+            // True, If node doesn't contains an image
+            const noImage = node.children.every((x) => {
+              if (x.type === 'element') return x.tagName !== 'img'
+              return true
+            })
+
+            return noImage ? '_blank' : false
+          },
+          rel(node) {
+            // True, If node doesn't contains an image
+            const noImage = node.children.every((x) => {
+              if (x.type === 'element') return x.tagName !== 'img'
+              return true
+            })
+
+            return noImage ? ['noopener', 'noreferrer'] : 'nofollow'
+          },
+          contentProperties: {className: ['alpha', 'bravo']},
+          content: {type: 'text', value: ' (opens in a new window)'}
+        })
         .process(
           `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
         )
     ),
     `<a href="http://example.com" target="_blank" rel="noopener noreferrer">http<span class="alpha bravo"> (opens in a new window)</span></a>\n<a href="http://example.com" rel="nofollow"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
     "should only add 'alpha bravo' classes to the span at the end of the link w/ `options(node)` function, whose node doesn't have an `img` element as a direct child"
-  )
-
-  t.equal(
-    String(
-      await rehype()
-        .use({settings: {fragment: true}})
-        .use(
-          rehypeExternalLinks,
-          /** @type {import("./index.js").inputOptions} */ (
-            () => {
-              return {
-                exclude: ['data-not-external', 'external-not'],
-                rel: ['noopener']
-              }
-            }
-          )
-        )
-        .process(
-          `<a href="http://example.com" data-not-external>none-https</a>\n<a href="http://example.com">http</a>\n<a href="http://example.com" external-not><img src="./image.png" /></a>`
-        )
-    ),
-    `<a href="http://example.com" data-not-external="">none-https</a>\n<a href="http://example.com" target="_blank" rel="noopener">http</a>\n<a href="http://example.com" external-not=""><img src="./image.png"></a>`,
-    "should only exclude all anchor except the middle anchor from having a `rel='noopener'` classes to the span at the end of the link w/ `options(node)` function, whose node doesn't have ['data-not-external', 'external-not'] properties"
   )
 
   t.end()

--- a/test.js
+++ b/test.js
@@ -216,7 +216,7 @@ test('rehypeExternalLinks', async (t) => {
           `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
         )
     ),
-    `<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http<span class="alpha bravo"> (opens in a new window)</span></a>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"></a>`,
+    `<a href="http://example.com" rel="nofollow">http<span class="alpha bravo"> (opens in a new window)</span></a>\n<a href="http://example.com" rel="nofollow"><img src="./image.png"></a>`,
     "should only add (open in window) text to the span at the end of the link w/ a `options(node)` function, whose node doesn't have an `img` element as a direct child"
   )
 
@@ -240,7 +240,7 @@ test('rehypeExternalLinks', async (t) => {
           `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
         )
     ),
-    `<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http<span> (opens in a new window)</span></a>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
+    `<a href="http://example.com" rel="nofollow">http<span> (opens in a new window)</span></a>\n<a href="http://example.com" rel="nofollow"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
     "should only add 'alpha bravo' classes to the span at the end of the link w/ a `options(node)` function, whose node doesn't have an `img` element as a direct child"
   )
 

--- a/test.js
+++ b/test.js
@@ -195,5 +195,153 @@ test('rehypeExternalLinks', async (t) => {
     'should add properties to the span at the end of the link w/ `contentProperties`'
   )
 
+  t.equal(
+    String(
+      await rehype()
+        .use({settings: {fragment: true}})
+        .use(
+          rehypeExternalLinks,
+          /** @type {import("./index.js").inputOptions} */ (
+            (node) => {
+              // True, If node doesn't contain an image
+              const noImage = node?.children?.every((x) => {
+                if (x.type === 'element') return x?.tagName !== 'img'
+                return true
+              })
+              return {
+                contentProperties: {className: ['alpha', 'bravo']},
+                content: noImage
+                  ? {type: 'text', value: ' (opens in a new window)'}
+                  : null
+              }
+            }
+          )
+        )
+        .process(
+          `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
+        )
+    ),
+    `<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http<span class="alpha bravo"> (opens in a new window)</span></a>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"></a>`,
+    "should only add (open in window) text to the span at the end of the link w/ a `options(node)` function, whose node doesn't have an `img` element as a direct child"
+  )
+
+  t.equal(
+    String(
+      await rehype()
+        .use({settings: {fragment: true}})
+        .use(
+          rehypeExternalLinks,
+          /** @type {import("./index.js").inputOptions} */ (
+            (node, tree) => {
+              // True, If parent node is a div
+              const divParent = tree?.children.some((x) => {
+                if (x.type === 'element') {
+                  return x?.tagName === 'div' && x?.children?.includes(node)
+                }
+
+                return false
+              })
+
+              return {
+                contentProperties: {className: ['alpha', 'bravo']},
+                content: divParent
+                  ? null
+                  : {type: 'text', value: ' (opens in a new window)'}
+              }
+            }
+          )
+        )
+        .process(
+          `<div><a href="http://example.com">http</a></div>\n<a href="http://example.com"><img src="./image.png" /></a>`
+        )
+    ),
+    `<div><a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http</a></div>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
+    "should only add (open in window) text to the span at the end of the link w/ a `options(node, tree)` function, whose tree doesn't has a `div` element as the parent of one of the node"
+  )
+
+  t.equal(
+    String(
+      await rehype()
+        .use({settings: {fragment: true}})
+        .use(
+          rehypeExternalLinks,
+          /** @type {import("./index.js").inputOptions} */ (
+            (node) => {
+              // True, If node doesn't contains an image
+              const noImage = !node?.children?.every((x) => {
+                if (x.type === 'element') return x?.tagName !== 'img'
+                return true
+              })
+
+              return {
+                contentProperties: noImage
+                  ? {className: ['alpha', 'bravo']}
+                  : null,
+                content: {type: 'text', value: ' (opens in a new window)'}
+              }
+            }
+          )
+        )
+        .process(
+          `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
+        )
+    ),
+    `<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http<span> (opens in a new window)</span></a>\n<a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
+    "should only add 'alpha bravo' classes to the span at the end of the link w/ a `options(node)` function, whose node doesn't have an `img` element as a direct child"
+  )
+
+  t.equal(
+    String(
+      await rehype()
+        .use({settings: {fragment: true}})
+        .use(
+          rehypeExternalLinks,
+          /** @type {import("./index.js").inputOptions} */ (
+            (node) => {
+              // True, If node doesn't contains an image
+              const noImage = node?.children?.every((x) => {
+                if (x.type === 'element') return x?.tagName !== 'img'
+                return true
+              })
+              return {
+                target: noImage ? '_blank' : false,
+                rel: noImage ? ['noopener', 'noreferrer'] : 'nofollow',
+                contentProperties: {className: ['alpha', 'bravo']},
+                content: {type: 'text', value: ' (opens in a new window)'}
+              }
+            }
+          )
+        )
+        .process(
+          `<a href="http://example.com">http</a>\n<a href="http://example.com"><img src="./image.png" /></a>`
+        )
+    ),
+    `<a href="http://example.com" target="_blank" rel="noopener noreferrer">http<span class="alpha bravo"> (opens in a new window)</span></a>\n<a href="http://example.com" rel="nofollow"><img src="./image.png"><span class="alpha bravo"> (opens in a new window)</span></a>`,
+    "should only add 'alpha bravo' classes to the span at the end of the link w/ `options(node)` function, whose node doesn't have an `img` element as a direct child"
+  )
+
+  t.equal(
+    String(
+      await rehype()
+        .use({settings: {fragment: true}})
+        .use(
+          rehypeExternalLinks,
+          /** @type {import("./index.js").inputOptions} */ (
+            () => {
+              return {
+                exclude: ['data-not-external', 'external-not'],
+                rel: ['noopener']
+              }
+            }
+          )
+        )
+        .process(
+          `<a href="http://example.com" data-not-external>none-https</a>\n<a href="http://example.com">http</a>\n<a href="http://example.com" external-not><img src="./image.png" /></a>`
+        )
+    ),
+    `<a href="http://example.com" data-not-external="">none-https</a>\n<a href="http://example.com" target="_blank" rel="noopener">http</a>\n<a href="http://example.com" external-not=""><img src="./image.png"></a>`,
+    "should only exclude all anchor except the middle anchor from having a `rel='noopener'` classes to the span at the end of the link w/ `options(node)` function, whose node doesn't have ['data-not-external', 'external-not'] properties"
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

- Adds supports for using a function as an argument, e.g.
```ts
import {rehype} from 'rehype'
import rehypeExternalLinks from 'rehype-external-links'
await rehype()
.use(
  rehypeExternalLinks,
  {
    target(node) {
      node.properties.id == 5 ? "_blank" : false
    }
  }
)
...
```

<!--do not edit: pr-->
